### PR TITLE
Add externalServices to extension.yaml

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -26,6 +26,10 @@ contributors:
   
 billingRequired: true
 
+externalServices:
+  - name: MessageBird
+    pricingUri: https://messagebird.com/pricing
+
 roles:
   - role: datastore.user
     reason: Allows this extension to access Cloud Firestore to read and process added documents.


### PR DESCRIPTION
Adding externalServices field to extension.yaml.

This is a migration of an existing field that used to live in https://extensions-registry.firebaseapp.com/extensions.json . It is shown to users during extension installation.
<img width="775" alt="Screen Shot 2021-10-05 at 4 59 21 PM" src="https://user-images.githubusercontent.com/4635763/136119881-80ff8c73-0653-46f1-8d6c-633e90ef208e.png">

Feel free to edit this field if a different link or API name is more appropriate!