### PR TITLE
chore: updated access key to have secret type field

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -104,7 +104,7 @@ params:
     immutable: true
 
   - param: ACCESS_KEY
-    type: string
+    type: secret
     label: MessageBird Access Key
     description: >-
       A MessageBird's REST api access key. For help creating an access key, refer to the 


### PR DESCRIPTION
Firebase now allows a `secret` type for sensitive information. 

This update allows access keys to be securely stored when configuring the extension